### PR TITLE
fix: add timeout parameter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.45.1'
+gem 'rubocop', '~> 1.76.1'
 gem 'rubocop-performance'
 gem 'rubocop-rake'
 gem 'simplecov'

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,9 @@ source 'https://rubygems.org'
 
 gemspec
 
+gem 'base64'
 gem 'rake', '~> 13.0'
-gem 'rubocop', '~> 1.76.1'
+gem 'rubocop', '~> 1.80.1'
 gem 'rubocop-performance'
 gem 'rubocop-rake'
 gem 'simplecov'

--- a/lib/playwrightrunner.rb
+++ b/lib/playwrightrunner.rb
@@ -20,15 +20,15 @@ module PlaywrightRunner
     config
   end
 
-  def mermaids_to_images(passed_config, src: '.', dest: '.', type: 'pdf')
+  def mermaids_to_images(passed_config, src: '.', dest: '.', type: 'pdf', timeout: 10_000)
     config = default_config(passed_config)
     Playwright.create(playwright_cli_executable_path: config[:playwright_path]) do |playwright|
-      playwright.chromium.launch(headless: true) do |browser|
+      playwright.chromium.launch(headless: true, timeout: timeout) do |browser|
         page = browser.new_page
         Dir.glob(File.join(src, '*.html')).each do |entry|
           id = File.basename(entry).sub('.html', '')
-          page.goto("file:///#{File.absolute_path(entry)}")
-          page.locator('svg').wait_for(state: 'visible')
+          page.goto("file:///#{File.absolute_path(entry)}", timeout: timeout)
+          page.locator('svg').wait_for(state: 'visible', timeout: timeout)
           sleep(1)
           1.upto(4) do
             bounds = page.locator('svg').bounding_box
@@ -46,7 +46,8 @@ module PlaywrightRunner
               page.set_viewport_size({ width: x + width, height: y + height })
 
               if type == 'png'
-                page.screenshot(path: File.join(dest, "#{id}.png"), clip: { x: x, y: y, width: width, height: height })
+                page.screenshot(path: File.join(dest, "#{id}.png"), clip: { x: x, y: y, width: width, height: height },
+                                timeout: timeout)
                 break
               end
 

--- a/playwright-runner.gemspec
+++ b/playwright-runner.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'playwright-ruby-client', '~> 1.0'
+  spec.add_dependency 'playwright-ruby-client', '>= 1.28.0'
 end


### PR DESCRIPTION
新し目の playwright-ruby-client を使うとRe:VIEWのテストが失敗するようなのでこちらを修正します。

どうもlaunchメソッドにはtimeoutパラメタを陽に渡す必要があるようでした。そのため、キーワード引数に追加するのと、指定がない場合はデフォルト値として10000を使うようにしています。

また、module_functionのところでrubocopが警告してくるようなので、rubocopのバージョンも新しくしています。